### PR TITLE
Set up Cursor Cloud dev environment (Qt 6.10.3 + build/run docs)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+Arachnel is a **Qt 6 / QML (C++20) desktop game launcher**. There is a single
+build artifact — the GUI app `arachnel_app`. There is currently no automated
+test suite and no repo-level lint config (the `unicase-source-formatting` skill
+targets a different project and does not apply here).
+
+### Toolchain (already provisioned in the VM snapshot)
+
+- **Qt 6.10.3** (official binaries via `aqtinstall`) at `~/Qt/6.10.3/gcc_64`.
+  Qt **6.10+ is required**: `CMakeLists.txt` calls
+  `find_package(Qt6 ... QuickPrivate)` unconditionally, and `QuickPrivate` only
+  exists as a separate CMake component from 6.10 onward (Ubuntu's apt Qt is
+  6.4 and will not work).
+- The `qtshadertools` module is installed (needed by the bundled `QmlMaterial`
+  dependency, which compiles shaders with `qsb`).
+- System libs (Mesa/GL, xkbcommon, xcb, DBus, fontconfig), `ninja-build`,
+  `pkg-config`, and `Xvfb` are installed.
+- A login shell exports `QT_ROOT`, prepends `$QT_ROOT/bin` to `PATH`, sets
+  `CMAKE_PREFIX_PATH`, and sets `QT_QML_MATERIAL_IMPORT_PATH` (see `~/.bashrc`).
+  If you use a **non-interactive** shell, export these yourself (see below).
+
+### Build
+
+`QmlMaterial` is pulled at CMake **configure** time via `FetchContent` from
+GitHub (network required, including its git submodules), and built into
+`build/qml_modules`.
+
+```bash
+export CMAKE_PREFIX_PATH="$HOME/Qt/6.10.3/gcc_64"
+export PATH="$HOME/Qt/6.10.3/gcc_64/bin:$PATH"
+# /usr/bin/c++ points at clang (which can't find libstdc++); force GCC:
+cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug \
+      -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+cmake --build build -j"$(nproc)"
+```
+
+`./run.sh` also works but does not pin the compiler, so a fresh `/usr/bin/c++`
+(clang) checkout can fail with `cannot find -lstdc++`; prefer the explicit
+`-DCMAKE_CXX_COMPILER=g++` above or keep `PATH`/`CMAKE_PREFIX_PATH` from `.bashrc`.
+
+### Run
+
+`arachnel_app` needs `QT_QML_MATERIAL_IMPORT_PATH` to point at the built
+`QmlMaterial` QML modules, otherwise the QML fails to load.
+
+```bash
+export QT_QML_MATERIAL_IMPORT_PATH=/workspace/build/qml_modules
+export DISPLAY=:1          # a real X display is at :1 for GUI/manual testing
+./build/arachnel_app
+```
+
+Gotchas:
+- **Do NOT set `QT_QPA_PLATFORM=offscreen` when you want a visible window.** With
+  `offscreen`, the process runs fine and loads all QML but never creates an X11
+  window (nothing appears on the desktop). Use `QT_QPA_PLATFORM=xcb` (or leave
+  unset) for the display at `:1`. `offscreen` is only useful for a headless
+  "does it load without QML errors" smoke check.
+- The `QML FontLoader: Cannot load font: MaterialSymbolsRounded...woff2`
+  warnings on startup are **non-fatal** and do not block rendering.
+- The app uses mock data (`CoreController::loadMockData`); core actions
+  (Play / Install / search / check-updates) push entries into the Active Tasks
+  queue and a snackbar — no external services are required.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Sets up the development environment for **Arachnel** (Qt 6 / QML C++20 desktop game launcher) so cloud agents can build, run, and manually test it.

The only code change is a new `AGENTS.md` documenting the toolchain and non-obvious gotchas. All heavy setup (Qt, system libs) is baked into the VM snapshot.

## Environment

- Installed **Qt 6.10.3** (official binaries via `aqtinstall`) at `~/Qt/6.10.3/gcc_64` with the `qtshadertools` module. Qt **6.10+ is required** because `CMakeLists.txt` unconditionally does `find_package(Qt6 ... QuickPrivate)`, and `QuickPrivate` only exists as a separate CMake component from 6.10 (Ubuntu's apt Qt is 6.4).
- Installed system deps: `ninja-build`, `pkg-config`, Mesa/GL, xkbcommon, xcb libs, DBus, fontconfig, `Xvfb`.
- Persisted Qt env vars in the login shell (`~/.bashrc`).

## Verified

- ✅ Configure: `cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++` (FetchContent pulls & builds `QmlMaterial` + shaders).
- ✅ Build: `cmake --build build -j$(nproc)` → `build/arachnel_app`.
- ✅ Run: launched on display `:1`, UI renders correctly (Material Design 3).
- ✅ QML sanity check: `qmlformat` parses all `qml/*.qml` files.
- ✅ Hello-world: navigated Library → Catalog, searched, and installed "Baldur's Gate 3", which added a task to the Active Tasks queue.

No automated test suite exists in the repo, and there is no repo-level lint config (the `unicase-source-formatting` skill targets a different project).

## Walkthrough

[arachnel_launcher_demo.mp4](https://cursor.com/agents/bc-7896c805-5f2e-4c0a-9054-529fc879d5a6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Farachnel_launcher_demo.mp4)

Navigation, catalog search, and installing a game (task appears in Active Tasks).

[Library UI](https://cursor.com/agents/bc-7896c805-5f2e-4c0a-9054-529fc879d5a6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Farachnel_library_ui.webp)
[Active tasks after install](https://cursor.com/agents/bc-7896c805-5f2e-4c0a-9054-529fc879d5a6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Farachnel_active_tasks.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7896c805-5f2e-4c0a-9054-529fc879d5a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7896c805-5f2e-4c0a-9054-529fc879d5a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

