### PR TITLE
fix: default FreeTP source on first launch + develop QA

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -10,13 +10,14 @@
 
 ---
 
-## Прогресс (обновлено 2026-07-09)
+## Прогресс (обновлено 2026-07-11)
 
 ### Сделано в этой итерации
 
 | Компонент | Статус |
 |-----------|--------|
-| **Фаза 0.1** SettingsStore | ✅ `~/.local/share/Arachnel/settings.json` |
+| **Фаза 0.1** SettingsStore | ✅ `~/.local/share/PetWork/Arachnel/settings.json` |
+| Дефолтный источник FreeTP | ✅ GitLab URL каталога при первом запуске |
 | **Фаза 0.2** LibraryStore | ✅ `library.json`, компоненты/DLC |
 | **Фаза 0.3** Убран mock | ✅ Библиотека из store, каталог из JSON-фида |
 | **Фаза 0.4** JobOrchestrator | ✅ Очередь torrent-задач, прогресс, отмена |

--- a/qml/settings/SettingsSourceFormPage.qml
+++ b/qml/settings/SettingsSourceFormPage.qml
@@ -28,9 +28,9 @@ Flickable {
         editing = false
         sourceId = ""
         sourceEnabled = true
-        nameField.text = ""
-        urlField.text = ""
-        descriptionField.text = ""
+        nameField.text = qsTr("FreeTP")
+        urlField.text = "https://gitlab.com/BadKiko/freetp-hydra-link/-/raw/main/games.json?ref_type=heads"
+        descriptionField.text = qsTr("Торрент-каталог FreeTP — magnet-ссылки и дополнения")
         errorLabel.text = ""
         nameField.forceActiveFocus()
     }

--- a/src/core/settings_store.cpp
+++ b/src/core/settings_store.cpp
@@ -140,7 +140,9 @@ void SettingsStore::load()
 {
     QFile file(settingsFilePath());
     if (!file.open(QIODevice::ReadOnly)) {
-        m_sources.clear();
+        if (m_sources.isEmpty())
+            m_sources = defaultSources();
+        save();
         emit libraryRootChanged();
         emit downloadsRootChanged();
         emit maxConcurrentDownloadsChanged();
@@ -184,8 +186,14 @@ void SettingsStore::load()
         }
     }
 
+    bool seededDefaults = false;
+    if (loaded.isEmpty()) {
+        loaded = defaultSources();
+        seededDefaults = true;
+    }
+
     m_sources = std::move(loaded);
-    if (migrated)
+    if (migrated || seededDefaults)
         save();
 
     emit libraryRootChanged();

--- a/src/core/source_plugin_model.cpp
+++ b/src/core/source_plugin_model.cpp
@@ -23,9 +23,24 @@ QString slugifySourceId(const QString& name)
     return slug;
 }
 
+QString defaultFreeTpCatalogUrl()
+{
+    return QStringLiteral(
+        "https://gitlab.com/BadKiko/freetp-hydra-link/-/raw/main/games.json?ref_type=heads");
+}
+
 QVector<SourcePluginInfo> defaultSources()
 {
-    return {};
+    SourcePluginInfo freetp;
+    freetp.id = QStringLiteral("freetp");
+    freetp.name = QStringLiteral("FreeTP");
+    freetp.description =
+        QStringLiteral("Торрент-каталог FreeTP — magnet-ссылки и дополнения");
+    freetp.catalogUrl = defaultFreeTpCatalogUrl();
+    freetp.iconName = QStringLiteral("storefront");
+    freetp.enabled = true;
+    freetp.capabilities = defaultCapabilities();
+    return {freetp};
 }
 
 SourcePluginModel::SourcePluginModel(QObject* parent)

--- a/src/core/source_plugin_model.h
+++ b/src/core/source_plugin_model.h
@@ -18,6 +18,7 @@ struct SourcePluginInfo {
 };
 
 QString slugifySourceId(const QString& name);
+QString defaultFreeTpCatalogUrl();
 QVector<SourcePluginInfo> defaultSources();
 
 class SourcePluginModel : public QAbstractListModel


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Full QA pass on `develop` found a critical first-run bug: empty catalog because `SettingsStore::load()` cleared default sources when `settings.json` was missing, and `defaultSources()` returned an empty list.

## Fixes

- **`defaultSources()`** — seeds FreeTP with the GitLab `freetp-hydra-link` catalog URL
- **`SettingsStore::load()`** — keeps constructor defaults on missing settings file; seeds defaults when the sources array is empty
- **`SettingsSourceFormPage`** — pre-fills FreeTP name/URL/description when adding a new source
- **`ROADMAP.md`** — updated progress date and correct AppData path (`PetWork/Arachnel`)

## QA (manual, DISPLAY=:1)

| Area | Result |
|------|--------|
| Launch, Material icons, navigation | ✅ |
| Library empty state | ✅ |
| Catalog (2742 games, FreeTP chip, covers) | ✅ |
| Game details + download button | ✅ |
| Downloads job card + live torrent progress | ✅ |
| Settings hub (Sources / Storage / Appearance) | ✅ |
| Global search ("Elden" → 5 results) | ✅ |

Demo video: catalog load, details, settings, download flow.

[arachnel-develop-qa-catalog.mp4](https://cursor.com/agents/bc-340cb945-d47c-4bde-a401-5fb3d813b59b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Farachnel-develop-qa-catalog.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-340cb945-d47c-4bde-a401-5fb3d813b59b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-340cb945-d47c-4bde-a401-5fb3d813b59b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

