### PR TITLE
fix: plugin catalog URL fallback and manifest version

### DIFF
--- a/src/core/core_controller.cpp
+++ b/src/core/core_controller.cpp
@@ -2512,11 +2512,23 @@ void CoreController::loadCatalogSourceNow(const QString& sourceId)
                     [this, watcher, sourceId]() {
                         const QVector<CatalogEntry> entries = watcher->result();
                         watcher->deleteLater();
-                        m_loadingSourceIds.remove(sourceId);
                         logDiagnostic(QStringLiteral("Plugin catalog ready: %1 entries=%2")
                                           .arg(sourceId)
                                           .arg(entries.size()));
                         if (entries.isEmpty()) {
+                            // DLL may ship without a bundled JSON; use catalogUrl when set.
+                            const QString catalogUrl = m_sources.catalogUrlFor(sourceId);
+                            if (!catalogUrl.isEmpty()) {
+                                logDiagnostic(
+                                    QStringLiteral(
+                                        "Plugin catalog empty; falling back to feed: %1 url=%2")
+                                        .arg(sourceId, catalogUrl));
+                                m_catalogHttpLoadActive = true;
+                                updateCatalogLoadingState();
+                                m_catalogLoader->loadFeed(QUrl(catalogUrl), sourceId);
+                                return;
+                            }
+                            m_loadingSourceIds.remove(sourceId);
                             if (m_activeSourceIds.contains(sourceId)) {
                                 showNotice(QCoreApplication::translate(
                                                "Core", "Catalog empty or unavailable: %1")

--- a/src/core/plugin_host.cpp
+++ b/src/core/plugin_host.cpp
@@ -331,7 +331,9 @@ bool PluginHost::loadPluginDir(const QString& dirPath)
     info.iconName = manifest.value(QStringLiteral("iconName")).toString(QStringLiteral("storefront"));
     info.enabled = true;
     info.isPlugin = true;
-    info.pluginVersion = loaded->instance->version();
+    // Prefer plugin.json version (CI bumps this); fall back to DLL if missing.
+    const QString manifestVersion = manifest.value(QStringLiteral("version")).toString().trimmed();
+    info.pluginVersion = !manifestVersion.isEmpty() ? manifestVersion : loaded->instance->version();
     info.pluginRootPath = dirPath;
     info.capabilities = loaded->instance->capabilities();
     info.apiVersion = exportedApi;


### PR DESCRIPTION
## Summary
- When a DLL plugin returns an empty catalog, fall back to its catalogUrl feed (fixes FreeTP installs that omit games-arachnel.json).
- Prefer plugin.json version in the plugins UI over a stale hardcoded DLL version().

## Test plan
- [ ] Install FreeTP without local catalog JSON → catalog loads from URL
- [ ] Plugins page shows FreeTP version matching plugin.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Новые возможности**
  * Добавлена автоматическая загрузка каталога по HTTP, если каталог плагина пуст, но указан сетевой адрес.

* **Исправления**
  * Улучшено определение версии плагина: теперь приоритет имеет версия из конфигурации, с резервным использованием версии самого плагина.
  * Скорректировано состояние загрузки и обработка недоступных каталогов.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->