### PR TITLE
fix: prefer catalog source when picking install plugin

### DIFF
--- a/src/core/install_analyzer.cpp
+++ b/src/core/install_analyzer.cpp
@@ -89,8 +89,10 @@ InstallPlan InstallAnalyzer::pickBestPlan(const QVector<Candidate>& candidates,
 
     for (const Candidate& candidate : candidates) {
         int score = candidate.analysis.confidence;
-        if (candidate.pluginId == sourceId)
-            score += 5;
+        // Prefer the catalog source plugin strongly so owns_download plugins
+        // (e.g. Steam) cannot steal FreeTP/torrent installs via a high confidence.
+        if (!sourceId.isEmpty() && candidate.pluginId == sourceId)
+            score += 50;
         if (!candidate.analysis.canInstall)
             score -= 100;
 


### PR DESCRIPTION
## Summary
- Raise catalog `sourceId` score bonus from +5 to +50 in `InstallAnalyzer`
- Prevents owns_download plugins (Steam) from stealing FreeTP/torrent installs after download

## Test plan
- [ ] Install a FreeTP torrent game with Steam plugin also installed
- [ ] Confirm install succeeds via FreeTP (no `startOwnedDownload` error)
- [ ] Steam owns_download install still works

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Исправления**
  * Улучшен выбор источника при установке плагинов.
  * При наличии указанного источника система теперь надежнее предпочитает соответствующий каталог-плагин.
  * Снижена вероятность того, что другой кандидат перехватит установку при высокой уверенности совпадения.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->