### PR TITLE
fix: avoid QML crash when launching or stopping a game

### DIFF
--- a/src/core/core_controller.cpp
+++ b/src/core/core_controller.cpp
@@ -2591,7 +2591,10 @@ void CoreController::touchLastPlayed(const QString& gameId)
     LibraryGame game = *existing;
     game.lastPlayedAt = QDateTime::currentDateTime().toString(Qt::ISODate);
     m_libraryStore.upsertGame(game);
-    syncLibraryFromStore();
+    enrichLibraryGameCover(game);
+    // Do not beginResetModel() here — launch/stop run from QML Button onClicked.
+    if (!m_library.replaceGame(game))
+        syncLibraryFromStore();
 }
 
 void CoreController::markGameRunning(const LibraryGame& game, const qint64 processId)
@@ -2700,7 +2703,12 @@ void CoreController::launchGame(const QString& gameId)
     QString error;
     qint64 processId = 0;
     if (ProcessLauncher::launch(resolved, &error, &processId)) {
-        markGameRunning(*game, processId);
+        // Defer RunningGameBar Loader + library bindings so we do not re-enter QML
+        // layout from inside Button onClicked (intermittent AV in Qt6Core on Windows).
+        const LibraryGame launched = *game;
+        QTimer::singleShot(0, this, [this, launched, processId]() {
+            markGameRunning(launched, processId);
+        });
         return;
     }
     showNotice(error.isEmpty() ? QCoreApplication::translate("Core", "Failed to launch game") : error);
@@ -2712,12 +2720,12 @@ void CoreController::stopRunningGame()
         return;
 
     if (m_runningProcessId <= 0) {
-        clearRunningGame();
+        QTimer::singleShot(0, this, [this]() { clearRunningGame(); });
         return;
     }
 
     if (ProcessTracker::terminateProcess(m_runningProcessId))
-        clearRunningGame();
+        QTimer::singleShot(0, this, [this]() { clearRunningGame(); });
     else
         showNotice(QCoreApplication::translate("Core", "Failed to stop game"));
 }

--- a/src/core/library_model.cpp
+++ b/src/core/library_model.cpp
@@ -111,6 +111,20 @@ void LibraryModel::setGames(QVector<LibraryGame> games)
     emit libraryChanged();
 }
 
+bool LibraryModel::replaceGame(const LibraryGame& game)
+{
+    for (int row = 0; row < m_games.size(); ++row) {
+        if (m_games.at(row).id != game.id)
+            continue;
+        m_games[row] = game;
+        const QModelIndex idx = index(row);
+        emit dataChanged(idx, idx);
+        emit libraryChanged();
+        return true;
+    }
+    return false;
+}
+
 const LibraryGame* LibraryModel::gameById(const QString& id) const
 {
     const QString resolved = repairCatalogEntryId(id);

--- a/src/core/library_model.h
+++ b/src/core/library_model.h
@@ -78,6 +78,8 @@ public:
     int count() const { return m_games.size(); }
 
     void setGames(QVector<LibraryGame> games);
+    // Surgical update — avoids beginResetModel() which can crash QML mid-click.
+    bool replaceGame(const LibraryGame& game);
     const LibraryGame* gameById(const QString& id) const;
     Q_INVOKABLE QVariantMap gameAt(int row) const;
     Q_INVOKABLE QVariantMap mostRecentGame() const;


### PR DESCRIPTION
## Summary
- Defer `markGameRunning` / `clearRunningGame` to the next event-loop tick so Play/Stop buttons do not re-enter QML layout mid-click
- Update `lastPlayedAt` via `LibraryModel::replaceGame` instead of a full `beginResetModel()`

## Test plan
- [ ] Launch a library game repeatedly from details and library hero
- [ ] Stop a running game from the RunningGameBar / Stop button
- [ ] Confirm no intermittent Arachnel crash on Windows

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Исправления**
  * Исправлено обновление обложек и отметки «Последняя игра» без перезагрузки всей библиотеки.
  * Повышена стабильность интерфейса при запуске и остановке игр.
  * Устранены возможные сбои и визуальные проблемы, возникавшие при синхронном обновлении состояния игры.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->