### PR TITLE
fix: stop RunningGameBar from stretching the main layout

### DIFF
--- a/qml/app/AppWindow.qml
+++ b/qml/app/AppWindow.qml
@@ -352,14 +352,20 @@ MD.ApplicationWindow {
                             spacing: 0
 
                             Loader {
+                                id: runningGameBarLoader
                                 Layout.fillWidth: true
+                                Layout.fillHeight: false
+                                // ColumnLayout otherwise stretches the Loader and leaves a huge
+                                // empty gap under the running-game chip.
+                                readonly property real barHeight: active && item ? item.implicitHeight : 0
+                                Layout.preferredHeight: barHeight
+                                Layout.maximumHeight: barHeight
                                 Layout.leftMargin: MD.Token.spacing.medium
                                 Layout.rightMargin: MD.Token.spacing.medium
-                                Layout.topMargin: root.detailsOpen && Core.gameRunning
-                                                    ? MD.Token.spacing.medium
-                                                    : 0
-                                Layout.bottomMargin: Core.gameRunning ? MD.Token.spacing.small : 0
+                                Layout.topMargin: active ? MD.Token.spacing.medium : 0
+                                Layout.bottomMargin: active ? MD.Token.spacing.small : 0
                                 active: Core.gameRunning
+                                visible: active
                                 sourceComponent: RunningGameBar {
                                     gameId: Core.runningGameId
                                     title: Core.runningGameTitle

--- a/qml/components/RunningGameBar.qml
+++ b/qml/components/RunningGameBar.qml
@@ -16,18 +16,14 @@ MD.Pane {
     backgroundColor: MD.Token.color.primary_container
     clip: true
 
-    implicitHeight: row.implicitHeight + 2 * padding
-
-    RowLayout {
-        id: row
-        anchors.left: parent.left
-        anchors.right: parent.right
-        anchors.verticalCenter: parent.verticalCenter
+    contentItem: RowLayout {
+        id: content
         spacing: MD.Token.spacing.small
 
         Rectangle {
             Layout.preferredWidth: 10
             Layout.preferredHeight: 10
+            Layout.alignment: Qt.AlignVCenter
             radius: 5
             color: MD.Token.color.primary
 
@@ -52,6 +48,7 @@ MD.Pane {
         GamePoster {
             Layout.preferredWidth: 40
             Layout.preferredHeight: 54
+            Layout.alignment: Qt.AlignVCenter
             source: root.coverUrl
             seed: root.title
             fallbackText: root.title.charAt(0)
@@ -60,6 +57,7 @@ MD.Pane {
 
         ColumnLayout {
             Layout.fillWidth: true
+            Layout.alignment: Qt.AlignVCenter
             spacing: 0
 
             MD.Label {
@@ -81,6 +79,7 @@ MD.Pane {
         }
 
         MD.Button {
+            Layout.alignment: Qt.AlignVCenter
             text: qsTr("Stop")
             mdState.type: MD.Enum.BtFilled
             mdState.backgroundColor: MD.Token.color.error


### PR DESCRIPTION
## Summary
- Constrain the running-game `Loader` height to the chip's `implicitHeight`
- Size `RunningGameBar` via `contentItem` so it no longer floats/centers in a stretched pane

## Test plan
- [ ] Launch a game from library and details
- [ ] Confirm the playing-now chip is compact with no huge empty gap below
- [ ] Stop the game — layout returns to normal

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Исправления**
  * Улучшено отображение панели запущенной игры: её высота и видимость теперь корректно адаптируются к содержимому и состоянию игры.
  * Исправлено вертикальное выравнивание элементов панели, включая обложку, информацию об игре и кнопку остановки.
  * Панель больше не зависит от открытия блока деталей при позиционировании.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->