### PR TITLE
fix: avoid null QObject crash on overlapping plugin catalog refresh

### DIFF
--- a/src/core/catalog/catalog_controller.cpp
+++ b/src/core/catalog/catalog_controller.cpp
@@ -75,7 +75,8 @@ CatalogController::CatalogController(CatalogModel* catalog, SourcePluginModel* s
 
 bool CatalogController::catalogLoading() const
 {
-    return !m_loadingSourceIds.isEmpty() || m_catalogHttpLoadActive;
+    return !m_loadingSourceIds.isEmpty() || m_catalogHttpLoadActive
+           || !m_inFlightPluginCatalogWatchers.isEmpty();
 }
 QString CatalogController::catalogStatus() const { return m_catalogStatus; }
 QString CatalogController::activeCatalogSourceId() const { return m_activeSourceIds.value(0); }
@@ -404,14 +405,27 @@ void CatalogController::startNextCatalogPrefetch()
 
 void CatalogController::waitForInFlightPluginCatalogLoads()
 {
+    // Stop scheduling more plugin->catalog() work before we block.
+    m_catalogPrefetchQueue.clear();
+
     // Snapshot — finished handlers may mutate the list while we wait.
     const QList<QObject*> watchers = m_inFlightPluginCatalogWatchers;
     for (QObject* obj : watchers) {
         auto* watcher = dynamic_cast<QFutureWatcher<QVector<CatalogEntry>>*>(obj);
         if (!watcher)
             continue;
+        // Drop queued finished handlers so they cannot start the next prefetch after unload.
+        QObject::disconnect(watcher, &QFutureWatcher<QVector<CatalogEntry>>::finished, this,
+                            nullptr);
         watcher->waitForFinished();
+        m_inFlightPluginCatalogWatchers.removeAll(watcher);
+        watcher->deleteLater();
     }
+}
+
+bool CatalogController::hasInFlightPluginCatalogLoads() const
+{
+    return !m_inFlightPluginCatalogWatchers.isEmpty();
 }
 
 } // namespace arachnel::core

--- a/src/core/catalog/catalog_controller.h
+++ b/src/core/catalog/catalog_controller.h
@@ -63,6 +63,7 @@ public:
     void prefetchCatalogCounts();
     /** Block until in-flight plugin->catalog() futures finish (call before unloading DLLs). */
     void waitForInFlightPluginCatalogLoads();
+    bool hasInFlightPluginCatalogLoads() const;
 
 signals:
     void catalogLoadingChanged(bool loading);

--- a/src/core/facade/core_controller.cpp
+++ b/src/core/facade/core_controller.cpp
@@ -229,6 +229,10 @@ CoreController::CoreController(QObject* parent)
     }
 
     QTimer::singleShot(5000, this, [this]() { scheduleOfficialPluginAutoUpdate(); });
+    connect(&m_settings, &SettingsStore::onboardingCompletedChanged, this, [this]() {
+        if (m_settings.onboardingCompleted())
+            QTimer::singleShot(1500, this, [this]() { scheduleOfficialPluginAutoUpdate(); });
+    });
 }
 
 

--- a/src/core/plugins/plugin_catalog_service.cpp
+++ b/src/core/plugins/plugin_catalog_service.cpp
@@ -88,6 +88,8 @@ void PluginCatalogService::setError(const QString& message)
 void PluginCatalogService::refresh()
 {
     if (m_catalogReply) {
+        // Capture-by-reply below; disconnect so an aborted reply cannot steal the new one.
+        QObject::disconnect(m_catalogReply, nullptr, this, nullptr);
         m_catalogReply->abort();
         m_catalogReply->deleteLater();
         m_catalogReply = nullptr;
@@ -102,16 +104,18 @@ void PluginCatalogService::refresh()
     request.setHeader(QNetworkRequest::UserAgentHeader,
                       QStringLiteral("Arachnel/%1").arg(QCoreApplication::applicationVersion()));
 
-    m_catalogReply = m_network->get(request);
-    connect(m_catalogReply, &QNetworkReply::finished, this, [this]() {
-        QNetworkReply* reply = m_catalogReply;
-        m_catalogReply = nullptr;
+    QNetworkReply* reply = m_network->get(request);
+    m_catalogReply = reply;
+    connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+        if (m_catalogReply == reply)
+            m_catalogReply = nullptr;
         setLoading(false);
-        if (!reply)
-            return;
-
         reply->deleteLater();
+
         if (reply->error() != QNetworkReply::NoError) {
+            // Superseded/aborted refresh — keep current list, don't wipe UI.
+            if (reply->error() == QNetworkReply::OperationCanceledError)
+                return;
             setError(QCoreApplication::translate("Core", "Could not load plugin list: %1")
                          .arg(reply->errorString()));
             m_plugins.clear();
@@ -239,6 +243,7 @@ void PluginCatalogService::processInstallQueue()
 void PluginCatalogService::downloadAndInstall(const QVariantMap& entry)
 {
     if (m_downloadReply) {
+        QObject::disconnect(m_downloadReply, nullptr, this, nullptr);
         m_downloadReply->abort();
         m_downloadReply->deleteLater();
         m_downloadReply = nullptr;
@@ -273,41 +278,36 @@ void PluginCatalogService::downloadAndInstall(const QVariantMap& entry)
     request.setHeader(QNetworkRequest::UserAgentHeader,
                       QStringLiteral("Arachnel/%1").arg(QCoreApplication::applicationVersion()));
 
-    m_downloadReply = m_network->get(request);
-    connect(m_downloadReply, &QNetworkReply::downloadProgress, this,
-            [this](qint64 received, qint64 total) {
+    QNetworkReply* reply = m_network->get(request);
+    m_downloadReply = reply;
+    connect(reply, &QNetworkReply::downloadProgress, this,
+            [this, reply](qint64 received, qint64 total) {
+                if (m_downloadReply != reply)
+                    return;
                 if (total > 0)
                     setDownloadProgress(static_cast<int>((received * 100) / total));
             });
-    connect(m_downloadReply, &QNetworkReply::readyRead, this, [this, outFile, hasher]() {
-        if (!m_downloadReply || !outFile)
+    connect(reply, &QNetworkReply::readyRead, this, [this, reply, outFile, hasher]() {
+        if (m_downloadReply != reply || !outFile)
             return;
-        const QByteArray chunk = m_downloadReply->readAll();
+        const QByteArray chunk = reply->readAll();
         if (chunk.isEmpty())
             return;
         hasher->addData(chunk);
         outFile->write(chunk);
     });
-    connect(m_downloadReply, &QNetworkReply::finished, this,
-            [this, expectedSha, pluginId, outFile, hasher, path]() {
-                QNetworkReply* reply = m_downloadReply;
-                m_downloadReply = nullptr;
+    connect(reply, &QNetworkReply::finished, this,
+            [this, reply, expectedSha, pluginId, outFile, hasher, path]() {
+                if (m_downloadReply == reply)
+                    m_downloadReply = nullptr;
                 const auto cleanup = qScopeGuard([outFile, hasher, reply]() {
                     if (outFile) {
                         outFile->close();
                         outFile->deleteLater();
                     }
                     delete hasher;
-                    if (reply)
-                        reply->deleteLater();
+                    reply->deleteLater();
                 });
-
-                if (!reply) {
-                    QFile::remove(path);
-                    finishInstallAttempt(pluginId, false,
-                                         QCoreApplication::translate("Core", "Download failed"));
-                    return;
-                }
 
                 // Flush any remaining buffered bytes.
                 const QByteArray rest = reply->readAll();
@@ -319,6 +319,11 @@ void PluginCatalogService::downloadAndInstall(const QVariantMap& entry)
 
                 if (reply->error() != QNetworkReply::NoError) {
                     QFile::remove(path);
+                    if (reply->error() == QNetworkReply::OperationCanceledError) {
+                        finishInstallAttempt(pluginId, false,
+                                             QCoreApplication::translate("Core", "Download failed"));
+                        return;
+                    }
                     const QString err =
                         QCoreApplication::translate("Core", "Download failed: %1")
                             .arg(reply->errorString());

--- a/src/core/plugins/plugin_facade.cpp
+++ b/src/core/plugins/plugin_facade.cpp
@@ -196,6 +196,10 @@ void CoreController::scheduleOfficialPluginAutoUpdate()
 {
     if (!m_pluginCatalog || !m_pluginHost)
         return;
+    // Onboarding already refreshes the official catalog; overlapping refresh() used to
+    // abort the in-flight QNetworkReply while its finished handler still ran (null write).
+    if (!m_settings.onboardingCompleted())
+        return;
 
     connect(m_pluginCatalog, &PluginCatalogService::pluginsChanged, this,
             &CoreController::runOfficialPluginAutoUpdate, Qt::SingleShotConnection);
@@ -208,7 +212,9 @@ void CoreController::runOfficialPluginAutoUpdate()
         return;
 
     // Don't unload plugin DLLs while QtConcurrent is still inside plugin->catalog().
-    if (m_catalogController && m_catalogController->catalogLoading()) {
+    if (m_catalogController
+        && (m_catalogController->catalogLoading()
+            || m_catalogController->hasInFlightPluginCatalogLoads())) {
         QTimer::singleShot(1500, this, &CoreController::runOfficialPluginAutoUpdate);
         return;
     }

--- a/src/core/settings/app_updater.cpp
+++ b/src/core/settings/app_updater.cpp
@@ -122,19 +122,23 @@ void AppUpdater::checkForUpdates(bool notifyIfUpToDate)
     request.setRawHeader("Accept", "application/vnd.github+json");
 
     if (m_activeReply) {
+        QObject::disconnect(m_activeReply, nullptr, this, nullptr);
         m_activeReply->abort();
         m_activeReply->deleteLater();
         m_activeReply = nullptr;
     }
 
-    m_activeReply = m_network->get(request);
-    connect(m_activeReply, &QNetworkReply::finished, this, [this, notifyIfUpToDate]() {
-        QNetworkReply* reply = m_activeReply;
-        m_activeReply = nullptr;
+    QNetworkReply* reply = m_network->get(request);
+    m_activeReply = reply;
+    connect(reply, &QNetworkReply::finished, this, [this, reply, notifyIfUpToDate]() {
+        if (m_activeReply == reply)
+            m_activeReply = nullptr;
         reply->deleteLater();
         setChecking(false);
 
         if (reply->error() != QNetworkReply::NoError) {
+            if (reply->error() == QNetworkReply::OperationCanceledError)
+                return;
             const QString error = QCoreApplication::translate("Core", "Update check failed: %1")
                                       .arg(reply->errorString());
             setLastError(error);
@@ -256,14 +260,18 @@ void AppUpdater::startDownload(const QUrl& url)
                          QNetworkRequest::NoLessSafeRedirectPolicy);
 
     if (m_activeReply) {
+        QObject::disconnect(m_activeReply, nullptr, this, nullptr);
         m_activeReply->abort();
         m_activeReply->deleteLater();
         m_activeReply = nullptr;
     }
 
-    m_activeReply = m_network->get(request);
-    connect(m_activeReply, &QNetworkReply::downloadProgress, this,
-            [this](qint64 received, qint64 total) {
+    QNetworkReply* reply = m_network->get(request);
+    m_activeReply = reply;
+    connect(reply, &QNetworkReply::downloadProgress, this,
+            [this, reply](qint64 received, qint64 total) {
+                if (m_activeReply != reply)
+                    return;
                 m_downloadBytesTotal = total;
                 if (total > 0)
                     m_downloadProgress = static_cast<int>((received * 100) / total);
@@ -271,29 +279,28 @@ void AppUpdater::startDownload(const QUrl& url)
                     m_downloadProgress = 0;
                 emit downloadProgressChanged();
             });
-    connect(m_activeReply, &QNetworkReply::readyRead, this, [this, outFile]() {
-        if (!m_activeReply || !outFile)
+    connect(reply, &QNetworkReply::readyRead, this, [this, reply, outFile]() {
+        if (m_activeReply != reply || !outFile)
             return;
-        outFile->write(m_activeReply->readAll());
+        outFile->write(reply->readAll());
     });
 
-    connect(m_activeReply, &QNetworkReply::finished, this, [this, outFile, targetPath]() {
-        QNetworkReply* reply = m_activeReply;
-        m_activeReply = nullptr;
+    connect(reply, &QNetworkReply::finished, this, [this, reply, outFile, targetPath]() {
+        if (m_activeReply == reply)
+            m_activeReply = nullptr;
 
-        if (reply)
-            outFile->write(reply->readAll());
+        outFile->write(reply->readAll());
         outFile->close();
         outFile->deleteLater();
-        if (reply)
-            reply->deleteLater();
+        reply->deleteLater();
 
-        if (!reply || reply->error() != QNetworkReply::NoError) {
+        if (reply->error() != QNetworkReply::NoError) {
             QFile::remove(targetPath);
             setDownloading(false);
+            if (reply->error() == QNetworkReply::OperationCanceledError)
+                return;
             const QString error = QCoreApplication::translate("Core", "Download failed: %1")
-                                      .arg(reply ? reply->errorString()
-                                                 : QCoreApplication::translate("Core", "Unknown error"));
+                                      .arg(reply->errorString());
             setLastError(error);
             setStatusText(error);
             emit updateFailed(error);


### PR DESCRIPTION
Capture the specific QNetworkReply in finished handlers, skip auto-update during onboarding, and wait/disconnect in-flight plugin catalog futures before unload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Исправления**
  * Повышена стабильность обновления и загрузки плагинов при повторных запусках и отмене операций.
  * Устранены ошибочные сбросы списка плагинов и интерфейса после отменённых запросов.
  * Предотвращены конфликты при одновременной загрузке каталогов и обновлении плагинов.
  * Обновления приложения и плагинов больше не запускаются до завершения первичной настройки.
  * Улучшена корректная очистка незавершённых сетевых операций и отображение ошибок загрузки.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->